### PR TITLE
fix: Workaround issue from clobClient.createOrDeriveApiKey

### DIFF
--- a/.changeset/rare-tigers-sink.md
+++ b/.changeset/rare-tigers-sink.md
@@ -1,0 +1,5 @@
+---
+"@iqai/mcp-polymarket": patch
+---
+
+Fix clob client errors on createOrDeriveApiKey


### PR DESCRIPTION
Hello! I'm working on making a trade bot backed by [clai](https://github.com/baalimago/clai) and I need a mcp server for polymarket to handle the trading. Found yours which worked quite well! But, one minor issue (not to the fault of your implementation)

## Description
There seems to be an issue with CLOB-client when using `createOrDeriveApiKey`: https://github.com/Polymarket/clob-client/issues/202 

So basically the client fails to create an API key for a wallet which already has one (or something like that, I'm not very into web3). Suggested solution in this PR is an adaption posted there.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Testing
`pnpm test` is not setup, so I only relied on manual testing

- [x] I have tested this change locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

I've tested this manually using clai as mcp server. 

## Changeset

- [x] I have added a changeset for this change (run `pnpm changeset` to add one)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - No docs update needed, IMO
- [x] My changes generate no new warnings