### PR TITLE
fix: Use StaticJsonRpcProvider to bypass network detection

### DIFF
--- a/src/services/approvals.ts
+++ b/src/services/approvals.ts
@@ -254,7 +254,7 @@ function getSignerFromEnv(): Wallet {
 		);
 	}
 	// Use StaticJsonRpcProvider to completely skip network auto-detection
-	const provider = new providers.StaticJsonRpcProvider(cfg.rpcUrl, cfg.chainId || 137);
+	const provider = new providers.StaticJsonRpcProvider(cfg.rpcUrl, cfg.chainId);
 	return new Wallet(cfg.privateKey, provider);
 }
 

--- a/src/services/redemption.ts
+++ b/src/services/redemption.ts
@@ -56,7 +56,7 @@ export class PolymarketRedemption {
 			);
 		}
 		// Use StaticJsonRpcProvider to completely skip network auto-detection
-		this.provider = new providers.StaticJsonRpcProvider(cfg.rpcUrl, cfg.chainId || 137);
+		this.provider = new providers.StaticJsonRpcProvider(cfg.rpcUrl, cfg.chainId);
 		this.signer = signer ?? new Wallet(cfg.privateKey, this.provider);
 	}
 


### PR DESCRIPTION
## Summary
- Replace `JsonRpcProvider` with `StaticJsonRpcProvider` to avoid "could not detect network" errors from flaky RPC endpoints
- Fix signature type auto-detection being overwritten by undefined values during config merge  
- Skip approval checks when using proxy wallet mode (signature type 2) since approvals are managed via Polymarket UI

## Problem
When using various Polygon RPC endpoints, ethers.js v5's `JsonRpcProvider` would fail with `could not detect network (event="noNetwork")` because it tries to auto-detect the network via `net_version` RPC call during initialization.

## Solution
Use `StaticJsonRpcProvider` which accepts the chainId directly and skips network auto-detection entirely. This makes the MCP server work reliably with any RPC endpoint.

## Changes
- `src/services/trading.ts` - StaticJsonRpcProvider + fix signature type detection + skip approvals for proxy wallets
- `src/services/approvals.ts` - StaticJsonRpcProvider
- `src/services/redemption.ts` - StaticJsonRpcProvider

## Test plan
- [x] Tested with `https://1rpc.io/matic` RPC endpoint
- [x] Verified order placement works with proxy wallet (funder address)
- [x] Confirmed signature type 2 is auto-detected when funderAddress is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)