### PR TITLE
feat: Add get_positions tool for portfolio valuation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,24 +77,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.1':
     resolution: {integrity: sha512-td5O8pFIgLs8H1sAZsD6v+5quODihyEw4nv2R8z7swUfIK1FKk+15e4eiYVLcAE4jUqngvh4j3JCNgg0Y4o4IQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.1':
     resolution: {integrity: sha512-Y3Ob4nqgv38Mh+6EGHltuN+Cq8aj/gyMTJYzkFZV2AEj+9XzoXB9VNljz9pjfFNHUxvLEV4b55VWyxozQTBaUQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.1':
     resolution: {integrity: sha512-PYWgEO7up7XYwSAArOpzsVCiqxBCXy53gsReAb1kKYIyXaoAlhBaBMvxR/k2Rm9aTuZ662locXUmPk/Aj+Xu+Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.1':
     resolution: {integrity: sha512-RHIG/zgo+69idUqVvV3n8+j58dKYABRpMyDmfWu2TITC+jwGPiEaT0Q3RKD+kQHiS80mpBrST0iUGeEXT0bU9A==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ async function main() {
 		server.addTool(tools.getBalanceAllowanceTool);
 		server.addTool(tools.updateBalanceAllowanceTool);
 		server.addTool(tools.redeemPositionsTool);
+		server.addTool(tools.getPositionsTool);
 
 		console.log(
 			"✅ Trading features enabled (POLYMARKET_PRIVATE_KEY is configured)",

--- a/src/tools/get-positions.ts
+++ b/src/tools/get-positions.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+import { getConfig } from "../services/config.js";
+
+const DATA_API_URL = "https://data-api.polymarket.com";
+
+const getPositionsSchema = z.object({
+	user: z
+		.string()
+		.optional()
+		.describe(
+			"Wallet address to fetch positions for. If not provided, uses POLYMARKET_FUNDER env var.",
+		),
+	limit: z
+		.number()
+		.optional()
+		.default(100)
+		.describe("Maximum number of positions to return (default: 100)"),
+});
+
+interface DataApiPosition {
+	proxyWallet: string;
+	asset: string;
+	conditionId: string;
+	size: number;
+	avgPrice: number;
+	initialValue: number;
+	currentValue: number;
+	cashPnl: number;
+	percentPnl: number;
+	totalBought: number;
+	realizedPnl: number;
+	percentRealizedPnl: number;
+	curPrice: number;
+	redeemable: boolean;
+	mergeable: boolean;
+	title: string;
+	slug: string;
+	icon?: string;
+	eventSlug?: string;
+	outcome: string;
+	outcomeIndex: number;
+	oppositeOutcome: string;
+	oppositeAsset: string;
+	endDate?: string;
+	negativeRisk: boolean;
+}
+
+export interface PositionOutput {
+	asset: string;
+	conditionId: string;
+	title: string;
+	slug: string;
+	outcome: string;
+	size: number;
+	avgPrice: number;
+	curPrice: number;
+	currentValue: number;
+	cashPnl: number;
+	percentPnl: number;
+	redeemable: boolean;
+}
+
+async function fetchPositions(
+	user: string,
+	limit: number,
+	redeemable: boolean,
+): Promise<DataApiPosition[]> {
+	const params = new URLSearchParams({
+		user,
+		limit: limit.toString(),
+		redeemable: redeemable.toString(),
+	});
+
+	const response = await fetch(`${DATA_API_URL}/positions?${params}`);
+
+	if (!response.ok) {
+		throw new Error(
+			`Data API request failed: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	return response.json();
+}
+
+export const getPositionsTool = {
+	name: "get_positions",
+	description:
+		"Get all positions for a wallet address with current values. Returns position details including size, current price, current value, and P&L. Uses the Polymarket Data API for accurate position valuation.",
+	parameters: getPositionsSchema,
+	execute: async (args: z.infer<typeof getPositionsSchema>) => {
+		const config = getConfig();
+		const userAddress = args.user ?? config.funderAddress;
+
+		if (!userAddress) {
+			throw new Error(
+				"No wallet address provided. Either pass 'user' parameter or set POLYMARKET_FUNDER environment variable.",
+			);
+		}
+
+		try {
+			// Fetch both active and redeemable positions
+			const [activePositions, redeemablePositions] = await Promise.all([
+				fetchPositions(userAddress, args.limit ?? 100, false),
+				fetchPositions(userAddress, args.limit ?? 100, true),
+			]);
+
+			// Combine and format positions
+			const allPositions = [...activePositions, ...redeemablePositions];
+
+			// Calculate totals
+			const totalValue = allPositions.reduce(
+				(sum, p) => sum + (Number(p.currentValue) || 0),
+				0,
+			);
+			const totalCashPnl = allPositions.reduce(
+				(sum, p) => sum + (Number(p.cashPnl) || 0),
+				0,
+			);
+
+			// Format positions for output
+			const positions: PositionOutput[] = allPositions.map((p) => ({
+				asset: p.asset,
+				conditionId: p.conditionId,
+				title: p.title,
+				slug: p.slug,
+				outcome: p.outcome,
+				size: Number(p.size),
+				avgPrice: Number(p.avgPrice),
+				curPrice: Number(p.curPrice),
+				currentValue: Number(p.currentValue),
+				cashPnl: Number(p.cashPnl),
+				percentPnl: Number(p.percentPnl),
+				redeemable: p.redeemable ?? false,
+			}));
+
+			return JSON.stringify(
+				{
+					walletAddress: userAddress,
+					totalPositions: positions.length,
+					totalValue: Math.round(totalValue * 100) / 100,
+					totalCashPnl: Math.round(totalCashPnl * 100) / 100,
+					positions,
+				},
+				null,
+				2,
+			);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new Error(`Failed to fetch positions: ${message}`);
+		}
+	},
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,6 +9,7 @@ export { getMarketsByTagTool } from "./get-markets-by-tag.js";
 export { getOpenOrdersTool } from "./get-open-orders.js";
 export { getOrderTool } from "./get-order.js";
 export { getOrderBookTool } from "./get-order-book.js";
+export { getPositionsTool } from "./get-positions.js";
 export { getTradeHistoryTool } from "./get-trade-history.js";
 export { listActiveMarketsTool } from "./list-active-markets.js";
 export { placeMarketOrderTool } from "./place-market-order.js";


### PR DESCRIPTION
## Summary
- Adds a new `get_positions` MCP tool that fetches positions from the Polymarket Data API
- Provides accurate position values that match the Polymarket UI
- **No new dependencies** - uses direct HTTP calls to `data-api.polymarket.com`

## Changes
- Created `src/tools/get-positions.ts` with the new tool
- Registered the tool in the trading tools section

## Usage
```
get_positions({ user?: "0x..." })
```

Returns:
```json
{
  "walletAddress": "0x...",
  "totalPositions": 2,
  "totalValue": 38.33,
  "totalCashPnl": 5.12,
  "positions": [
    {
      "asset": "...",
      "title": "Market Question",
      "slug": "market-slug",
      "outcome": "Yes",
      "size": 85,
      "avgPrice": 0.058,
      "curPrice": 0.06,
      "currentValue": 5.10,
      "cashPnl": 0.17,
      "percentPnl": 3.4,
      "redeemable": false
    }
  ]
}
```

## Why
The existing approach of using `get_balance_allowance` + `get_order_book` for portfolio valuation was giving incorrect values because it used bid/ask midpoint instead of the Data API's `currentValue` calculation. This caused ~60% undervaluation of positions.

## Test plan
- [x] Build passes
- [ ] Test with a wallet that has open positions
- [ ] Verify totalValue matches Polymarket UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes: https://github.com/IQAIcom/mcp-polymarket/issues/47