### PR TITLE
chore: add changeset for PR #50 (MCP logging + RPC env rename)

### DIFF
--- a/.changeset/fix-mcp-logging-and-rpc-env.md
+++ b/.changeset/fix-mcp-logging-and-rpc-env.md
@@ -1,0 +1,9 @@
+---
+"@iqai/mcp-polymarket": patch
+---
+
+Fix MCP protocol logging and rename RPC environment variable
+
+- Route all server log output to stderr so it no longer corrupts the MCP stdout JSON-RPC stream
+- Rename `POLYMARKET_RPC_URL` to `POLYGON_RPC_URL` (update your env/config accordingly)
+- Remove emoji characters from log messages

--- a/.github/workflows/sync-tools.yml
+++ b/.github/workflows/sync-tools.yml
@@ -19,12 +19,16 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.0.0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: Install dependencies
         run: |
           if [ -f pnpm-lock.yaml ]; then
-            corepack enable
             pnpm install --frozen-lockfile
           else
             npm install


### PR DESCRIPTION
## Summary
Two fixes for problems introduced by PR #50:

1. **Missing changeset** — PR #50 (`db49477`) shipped two user-visible fixes (routing logs to stderr to unblock MCP stdio + renaming `POLYMARKET_RPC_URL` → `POLYGON_RPC_URL`) but landed without a changeset, so the release workflow never bumped `@iqai/mcp-polymarket` past `0.0.16` and the fixes are not on npm. This PR adds a `patch` changeset so the next merge to `main` opens a Version Packages PR and publishes `0.0.17`.

2. **`Sync MCP Tool Docs` workflow broken on every push** — Corepack was resolving to pnpm `11.1.1`, which requires Node ≥22.13 and imports `node:sqlite` (a built-in only present in Node 22+). The workflow pinned Node 20 and ran bare `corepack enable`, so every run failed with `ERR_UNKNOWN_BUILTIN_MODULE: No such built-in module: node:sqlite` before the docs sync could run ([failing run](https://github.com/IQAIcom/mcp-polymarket/actions/runs/25789844201/job/75752284181)). Aligned `sync-tools.yml` with the pattern from `release.yml`/`push.yml`: Node `22.0.0` and `pnpm/action-setup@v4` pinned to `version: 9`.

## Test plan
- [ ] After merge, confirm the `Sync MCP Tool Docs` run on `main` passes
- [ ] Confirm the release workflow opens a `Version Packages` PR
- [ ] Verify `0.0.17` lands on npm with the PR #50 changes