### PR TITLE
chore: add changeset for cleanup patch (#54, #55)

### DIFF
--- a/.changeset/cleanup-patch.md
+++ b/.changeset/cleanup-patch.md
@@ -1,0 +1,9 @@
+---
+"@iqai/mcp-polymarket": patch
+---
+
+Cleanup batch:
+
+- Fix stderr log lines running together due to missing trailing newlines on init/order/market-order logs (server log output is no longer corrupted into one line)
+- Reject invalid `outcomeIndex` for negRisk redemption instead of silently defaulting to outcome 0 — prevents accidentally redeeming the losing side when the caller passes a bad value
+- Move `shx` from `dependencies` to `devDependencies` so npm consumers don't pull it in


### PR DESCRIPTION
## Summary
Adds a `patch` changeset so the next merge to `main` opens a Version Packages PR and publishes the user-visible fixes from #54 and #55 to npm.

User-facing notes in the changeset:
- Fix stderr log lines running together due to missing trailing newlines
- Reject invalid `outcomeIndex` for negRisk redemption instead of silently defaulting to outcome 0 (prevented accidentally redeeming the losing side)
- Move `shx` from `dependencies` to `devDependencies`

## Test plan
- [ ] Release workflow opens a `Version Packages` PR bumping `@iqai/mcp-polymarket` to `0.0.18`
- [ ] Merging that PR publishes `0.0.18` to npm